### PR TITLE
Update main.tf

### DIFF
--- a/black_lion/main.tf
+++ b/black_lion/main.tf
@@ -166,7 +166,7 @@ resource "docker_container" "vault_oss_server" {
 
   networks_advanced {
     name         = "vaultron-network"
-    ipv4_address = "${format("10.10.42.20%d", count.index)}"
+    ipv4_address = "format("10.10.42.20%d", count.index)"
   }
 
   volumes {
@@ -306,7 +306,7 @@ resource "docker_container" "vault_custom_server" {
 
   networks_advanced {
     name         = "vaultron-network"
-    ipv4_address = "${format("10.10.42.20%d", count.index)}"
+    ipv4_address = "format("10.10.42.20%d", count.index)"
   }
 
   volumes {


### PR DESCRIPTION
Warning: Interpolation-only expressions are deprecated

  on black_lion/main.tf line 169, in resource "docker_container" "vault_oss_server":
 169:     ipv4_address = "${format("10.10.42.20%d", count.index)}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.


Warning: Interpolation-only expressions are deprecated

  on black_lion/main.tf line 309, in resource "docker_container" "vault_custom_server":
 309:     ipv4_address = "${format("10.10.42.20%d", count.index)}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.