### PR TITLE
Update main.tf

### DIFF
--- a/red_lion/main.tf
+++ b/red_lion/main.tf
@@ -519,7 +519,7 @@ resource "docker_container" "consul_oss_client" {
 
   networks_advanced {
     name         = "vaultron-network"
-    ipv4_address = "${format("10.10.42.4%d", count.index)}"
+    ipv4_address = "format("10.10.42.4%d", count.index)"
   }
 
   upload {


### PR DESCRIPTION
Warning: Interpolation-only expressions are deprecated

  on red_lion/main.tf line 522, in resource "docker_container" "consul_oss_client":
 522:     ipv4_address = "${format("10.10.42.4%d", count.index)}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.